### PR TITLE
Simplify getNextJsHeaders arguments

### DIFF
--- a/api-extractor/next-utils.api.json
+++ b/api-extractor/next-utils.api.json
@@ -215,7 +215,7 @@
             },
             {
               "kind": "Content",
-              "text": "({ headers, }: {\n    headers: {\n        [headerName: string]: string;\n    };\n}) => {\n    key: string;\n    value: string;\n}[]"
+              "text": "(headers: {\n    [headerName: string]: string;\n}) => {\n    key: string;\n    value: string;\n}[]"
             }
           ],
           "releaseTag": "Public",

--- a/api-extractor/next-utils.api.md
+++ b/api-extractor/next-utils.api.md
@@ -11,10 +11,8 @@ import { LinkProps } from 'next/link';
 export const AslLink: FC<LinkProps>;
 
 // @public
-export const getNextJsHeaders: ({ headers, }: {
-    headers: {
-        [headerName: string]: string;
-    };
+export const getNextJsHeaders: (headers: {
+    [headerName: string]: string;
 }) => {
     key: string;
     value: string;

--- a/docs/next-utils.getnextjsheaders.md
+++ b/docs/next-utils.getnextjsheaders.md
@@ -9,10 +9,8 @@ Get Next.js headers array from object containing header values by name.
 <b>Signature:</b>
 
 ```typescript
-getNextJsHeaders: ({ headers, }: {
-    headers: {
-        [headerName: string]: string;
-    };
+getNextJsHeaders: (headers: {
+    [headerName: string]: string;
 }) => {
     key: string;
     value: string;

--- a/src/getNextJsHeaders.ts
+++ b/src/getNextJsHeaders.ts
@@ -5,12 +5,8 @@ type NextJsHeadersArray = Header["headers"];
 /**
  * Get Next.js headers array from object containing header values by name.
  */
-const getNextJsHeaders = ({
-  headers,
-}: {
-  headers: {
-    [headerName: string]: string;
-  };
+const getNextJsHeaders = (headers: {
+  [headerName: string]: string;
 }): NextJsHeadersArray =>
   Object.keys(headers).map((headerName) => ({
     key: headerName,

--- a/types/next-utils.d.ts
+++ b/types/next-utils.d.ts
@@ -23,10 +23,8 @@ export declare const AslLink: FC<LinkProps>;
 /**
  * Get Next.js headers array from object containing header values by name.
  */
-export declare const getNextJsHeaders: ({ headers, }: {
-    headers: {
-        [headerName: string]: string;
-    };
+export declare const getNextJsHeaders: (headers: {
+    [headerName: string]: string;
 }) => {
     key: string;
     value: string;


### PR DESCRIPTION
Replaced object argument with a single `headers` key with single positional argument.

Closes #7